### PR TITLE
Add asynchronous 'finally' equivalent to TransformableFuture

### DIFF
--- a/lib/src/main/java/org/esbtools/eventhandler/FailedTransformableFuture.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/FailedTransformableFuture.java
@@ -18,12 +18,17 @@
 
 package org.esbtools.eventhandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 final class FailedTransformableFuture<T> implements TransformableFuture<T> {
     private final Exception exception;
+
+    private static final Logger log = LoggerFactory.getLogger(FailedTransformableFuture.class);
 
     public FailedTransformableFuture(Exception exception) {
         this.exception = exception;
@@ -70,5 +75,16 @@ final class FailedTransformableFuture<T> implements TransformableFuture<T> {
     public TransformableFuture<Void> transformAsyncIgnoringReturn(
             FutureTransform<T, TransformableFuture<?>> futureTransform) {
         return new FailedTransformableFuture<>(exception);
+    }
+
+    @Override
+    public TransformableFuture<T> whenDoneOrCancelled(FutureDoneCallback callback) {
+        try {
+            callback.onDoneOrCancelled();
+        } catch (Exception e) {
+            log.warn("Exception caught and ignored while running future done callback.", e);
+        }
+
+        return this;
     }
 }

--- a/lib/src/main/java/org/esbtools/eventhandler/FutureDoneCallback.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/FutureDoneCallback.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2015 esbtools Contributors and/or its affiliates.
+ *  Copyright 2016 esbtools Contributors and/or its affiliates.
  *
  *  This file is part of esbtools.
  *
@@ -18,13 +18,6 @@
 
 package org.esbtools.eventhandler;
 
-/**
- * A function applied to a {@link TransformableFuture} which returns some result of type {@code O},
- * or throws an exception if unable to compute a result.
- *
- * @param <I> The type of input
- * @param <O> The type of output
- */
-public interface FutureTransform<I, O> {
-    O transform(I input) throws Exception;
+public interface FutureDoneCallback {
+    void onDoneOrCancelled() throws Exception;
 }

--- a/lib/src/main/java/org/esbtools/eventhandler/NestedTransformableFuture.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/NestedTransformableFuture.java
@@ -82,15 +82,22 @@ public class NestedTransformableFuture<U> implements TransformableFuture<U> {
                 nextFuture -> nextFuture.transformAsyncIgnoringReturn(futureTransform));
     }
 
+    /**
+     * Because the result in this context is the result of a nested future, and "done" implies
+     * having a result, we put off calling the callbacks until the nested future is done to
+     * coincide with when this future has a result.
+     */
     @Override
     public TransformableFuture<U> whenDoneOrCancelled(FutureDoneCallback callback) {
         nestedFuture.whenDoneOrCancelled(() -> {
+            final TransformableFuture<U> nextFuture;
             try {
-                TransformableFuture<U> nextFuture = nestedFuture.get();
-                nextFuture.whenDoneOrCancelled(callback);
+                nextFuture = nestedFuture.get();
             } catch (Exception e) {
                 callback.onDoneOrCancelled();
+                return;
             }
+            nextFuture.whenDoneOrCancelled(callback);
         });
         return this;
     }

--- a/lib/src/main/java/org/esbtools/eventhandler/NestedTransformableFuture.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/NestedTransformableFuture.java
@@ -81,4 +81,17 @@ public class NestedTransformableFuture<U> implements TransformableFuture<U> {
         return nestedFuture.transformAsync(
                 nextFuture -> nextFuture.transformAsyncIgnoringReturn(futureTransform));
     }
+
+    @Override
+    public TransformableFuture<U> whenDoneOrCancelled(FutureDoneCallback callback) {
+        nestedFuture.whenDoneOrCancelled(() -> {
+            try {
+                TransformableFuture<U> nextFuture = nestedFuture.get();
+                nextFuture.whenDoneOrCancelled(callback);
+            } catch (Exception e) {
+                callback.onDoneOrCancelled();
+            }
+        });
+        return this;
+    }
 }

--- a/lib/src/main/java/org/esbtools/eventhandler/TransformableFuture.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/TransformableFuture.java
@@ -87,4 +87,14 @@ public interface TransformableFuture<T> extends Future<T> {
      * because the consumer is ignoring the return value. This would definitely be a bug.
      */
     TransformableFuture<Void> transformAsyncIgnoringReturn(FutureTransform<T, TransformableFuture<?>> futureTransform);
+
+    /**
+     * An asynchronous "finally" block.
+     *
+     * <p>Use to clean up resources or whatever finishing behavior that needs to happen whenever the
+     * future has a result or is cancelled.
+     *
+     * <p>If the future is already done or cancelled, the callback is called immediately.
+     */
+    TransformableFuture<T> whenDoneOrCancelled(FutureDoneCallback callback);
 }

--- a/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/client/BulkLightblueRequester.java
+++ b/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/client/BulkLightblueRequester.java
@@ -245,6 +245,7 @@ public class BulkLightblueRequester implements LightblueRequester {
 
             result = responses;
             completed = true;
+            callDoneCallbacks();
 
             for (LazyTransformingFuture<U, ?> next : this.next) {
                 try {
@@ -254,14 +255,13 @@ public class BulkLightblueRequester implements LightblueRequester {
                             "future.", e);
                 }
             }
-
-            callDoneCallbacks();
         }
 
         void completeExceptionally(Exception exception) {
             if (isDone()) return;
             completed = true;
             this.exception = exception;
+            callDoneCallbacks();
 
             for (LazyTransformingFuture<U, ?> next : this.next) {
                 try {
@@ -271,8 +271,6 @@ public class BulkLightblueRequester implements LightblueRequester {
                             "future with exception.", e);
                 }
             }
-
-            callDoneCallbacks();
         }
 
         @Override

--- a/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/client/BulkLightblueRequester.java
+++ b/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/client/BulkLightblueRequester.java
@@ -18,6 +18,7 @@
 
 package org.esbtools.eventhandler.lightblue.client;
 
+import org.esbtools.eventhandler.FutureDoneCallback;
 import org.esbtools.eventhandler.FutureTransform;
 import org.esbtools.eventhandler.NestedTransformableFuture;
 import org.esbtools.eventhandler.NestedTransformableFutureIgnoringReturn;
@@ -33,6 +34,8 @@ import com.redhat.lightblue.client.response.LightblueBulkDataResponse;
 import com.redhat.lightblue.client.response.LightblueBulkResponseException;
 import com.redhat.lightblue.client.response.LightblueDataResponse;
 import com.redhat.lightblue.client.response.LightblueErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -225,6 +228,10 @@ public class BulkLightblueRequester implements LightblueRequester {
          */
         private final List<LazyTransformingFuture<U, ?>> next = new ArrayList<>(1);
 
+        private final List<FutureDoneCallback> doneCallbacks = new ArrayList<>();
+
+        private static Logger log = LoggerFactory.getLogger(LazyTransformableFuture.class);
+
         /**
          * @param completer Reference to a function which should complete this future when called.
          *                  See {@link #completer}.
@@ -236,31 +243,43 @@ public class BulkLightblueRequester implements LightblueRequester {
         void complete(U responses) {
             if (isDone()) return;
 
-            try {
-                result = responses;
-                completed = true;
-                for (LazyTransformingFuture<U, ?> next : this.next) {
+            result = responses;
+            completed = true;
+
+            for (LazyTransformingFuture<U, ?> next : this.next) {
+                try {
                     next.complete(result);
+                } catch (Exception e) {
+                    log.warn("Exception caught and ignored while completing next transforming " +
+                            "future.", e);
                 }
-            } catch (Exception e) {
-                completeExceptionally(e);
             }
+
+            callDoneCallbacks();
         }
 
         void completeExceptionally(Exception exception) {
             if (isDone()) return;
             completed = true;
             this.exception = exception;
+
             for (LazyTransformingFuture<U, ?> next : this.next) {
-                next.completeExceptionally(exception);
+                try {
+                    next.completeExceptionally(exception);
+                } catch (Exception e) {
+                    log.warn("Exception caught and ignored while completing next transforming " +
+                            "future with exception.", e);
+                }
             }
+
+            callDoneCallbacks();
         }
 
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
             if (completed) return false;
             cancelled = true;
-            next.clear();
+            callDoneCallbacks();
             return true;
         }
 
@@ -331,6 +350,30 @@ public class BulkLightblueRequester implements LightblueRequester {
             next.add(future);
             return new NestedTransformableFutureIgnoringReturn(future);
         }
+
+        @Override
+        public TransformableFuture<U> whenDoneOrCancelled(FutureDoneCallback callback) {
+            if (isDone()) {
+                try {
+                    callback.onDoneOrCancelled();
+                } catch (Exception e) {
+                    log.warn("Exception caught and ignored while running future done callback.", e);
+                }
+                return this;
+            }
+            doneCallbacks.add(callback);
+            return this;
+        }
+
+        private void callDoneCallbacks() {
+            for (FutureDoneCallback doneCallback : doneCallbacks) {
+                try {
+                    doneCallback.onDoneOrCancelled();
+                } catch (Exception e) {
+                    log.warn("Exception caught and ignored while running future done callback.", e);
+                }
+            }
+        }
     }
 
     /**
@@ -376,6 +419,12 @@ public class BulkLightblueRequester implements LightblueRequester {
         }
 
         @Override
+        public TransformableFuture<LightblueResponses> whenDoneOrCancelled(FutureDoneCallback callback) {
+            backingFuture.whenDoneOrCancelled(callback);
+            return this;
+        }
+
+        @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
             if (!backingFuture.isDone()) {
                 queuedRequests.remove(this);
@@ -417,11 +466,11 @@ public class BulkLightblueRequester implements LightblueRequester {
      * @param <U> The output type as a result of applying the transform function to the input.
      */
     static class LazyTransformingFuture<T, U> implements TransformableFuture<U> {
-        private final FutureTransform<T, U> handler;
+        private final FutureTransform<T, U> transform;
         private final LazyTransformableFuture<U> backingFuture;
 
-        LazyTransformingFuture(FutureTransform<T, U> handler, Completer completer) {
-            this.handler = handler;
+        LazyTransformingFuture(FutureTransform<T, U> transform, Completer completer) {
+            this.transform = transform;
             this.backingFuture = new LazyTransformableFuture<>(completer);
         }
 
@@ -429,8 +478,8 @@ public class BulkLightblueRequester implements LightblueRequester {
             if (isDone()) return;
 
             try {
-                U handled = handler.handle(responses);
-                backingFuture.complete(handled);
+                U transformed = transform.transform(responses);
+                backingFuture.complete(transformed);
             } catch (Exception e) {
                 completeExceptionally(e);
             }
@@ -485,6 +534,12 @@ public class BulkLightblueRequester implements LightblueRequester {
         public TransformableFuture<Void> transformAsyncIgnoringReturn(
                 FutureTransform<U, TransformableFuture<?>> futureTransform) {
             return backingFuture.transformAsyncIgnoringReturn(futureTransform);
+        }
+
+        @Override
+        public TransformableFuture<U> whenDoneOrCancelled(FutureDoneCallback callback) {
+            backingFuture.whenDoneOrCancelled(callback);
+            return this;
         }
     }
 


### PR DESCRIPTION
This is necessary for cleaning up resources such as locks once an async request/response chain is complete (or fails, or is cancelled).

We never do cancellation in practice but, we are abiding by the future interface so it's there too.

I also fixed a few minor "bugs" (more like misleading code) in the existing future implementation.