### PR TITLE
Send failures without messages to DLQ in retry route

### DIFF
--- a/lib/src/main/java/org/esbtools/eventhandler/RetryingBatchFailedMessageRoute.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/RetryingBatchFailedMessageRoute.java
@@ -79,7 +79,7 @@ public class RetryingBatchFailedMessageRoute extends RouteBuilder {
                 // Indenting because delay actually starts a child processor, and needs its own end()
                 // See: https://issues.apache.org/jira/browse/CAMEL-2654
                 .process(exchange -> {
-                    Integer retryAttempt = Optional.ofNullable(
+                    int retryAttempt = Optional.ofNullable(
                             exchange.getProperty(NEXT_ATTEMPT_NUMBER_PROPERTY, Integer.class))
                             .orElse(FIRST_ATTEMPT_NUMBER);
                     // Preemptively increment retry attempt for next loop.
@@ -114,6 +114,7 @@ public class RetryingBatchFailedMessageRoute extends RouteBuilder {
                             log.warn("Failed message had no parsed message. There is no message " +
                                     "to retry without trying to parse again, which is usually " +
                                     "fruitless. Sending to dead letter URI {}.", deadLetterUri);
+                            newFailures.add(failure);
                             continue;
                         }
 

--- a/lib/src/test/java/org/esbtools/eventhandler/RetryingBatchFailedMessageRouteTest.java
+++ b/lib/src/test/java/org/esbtools/eventhandler/RetryingBatchFailedMessageRouteTest.java
@@ -228,6 +228,22 @@ public class RetryingBatchFailedMessageRouteTest extends CamelTestSupport {
                 .inOrder();
     }
 
+    @Test
+    public void shouldSendFailuresWithoutMessagesStraightToDlq() throws Exception {
+        FailedMessage noMsgFailure = new FailedMessage("original", new Exception("Simulated failure"));
+
+        toDlq.expectedMessageCount(1);
+
+        toFailureRetry5Retries.sendBody(Collections.singletonList(noMsgFailure));
+
+        toDlq.assertIsSatisfied();
+
+        Collection<FailedMessage> deadLetters =
+                toDlq.getExchanges().get(0).getIn().getMandatoryBody(Collection.class);
+
+        Truth.assertThat(deadLetters).containsExactly(noMsgFailure);
+    }
+
     static String exceptionMessageForRetryAttempt(int processCount) {
         return "Simulated retry failure " + processCount;
     }


### PR DESCRIPTION
Fixes #64 