### PR TITLE
Add TransformableFuture.combined

### DIFF
--- a/lib/src/main/java/org/esbtools/eventhandler/CombinedTransformableFuture.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/CombinedTransformableFuture.java
@@ -1,0 +1,217 @@
+package org.esbtools.eventhandler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CombinedTransformableFuture<T> implements TransformableFuture<List<T>> {
+    private final List<TransformableFuture<? extends T>> futures;
+    private final List<FutureDoneCallback> doneCallbacks = new ArrayList<>();
+
+    public CombinedTransformableFuture(TransformableFuture<? extends T>... futures) {
+        this.futures = Arrays.asList(futures);
+        initDoneCallbacks();
+    }
+
+    public CombinedTransformableFuture(List<TransformableFuture<? extends T>> futures) {
+        this.futures = new ArrayList<>(futures);
+        initDoneCallbacks();
+    }
+
+    private void initDoneCallbacks() {
+        AtomicInteger doneCount = new AtomicInteger(0);
+        this.futures.forEach(f -> f.whenDoneOrCancelled(() -> {
+            if (doneCount.incrementAndGet() == this.futures.size()) {
+                doneCallbacks.forEach(this::doCallback);
+            }
+        }));
+    }
+
+    @Override
+    public <U> TransformableFuture<U> transformSync(FutureTransform<List<T>, U> futureTransform) {
+        return new CombinedTransformingFuture<>(this, futureTransform);
+    }
+
+    @Override
+    public <U> TransformableFuture<U> transformAsync(FutureTransform<List<T>, TransformableFuture<U>> futureTransform) {
+        return new NestedTransformableFuture<>(
+                new CombinedTransformingFuture<>(this, futureTransform));
+    }
+
+    @Override
+    public TransformableFuture<Void> transformAsyncIgnoringReturn(FutureTransform<List<T>, TransformableFuture<?>> futureTransform) {
+        return new NestedTransformableFutureIgnoringReturn(
+                new CombinedTransformingFuture<>(this, futureTransform));
+    }
+
+    @Override
+    public TransformableFuture<List<T>> whenDoneOrCancelled(FutureDoneCallback callback) {
+        // TODO: there is a race condition here
+        if (isDone()) {
+            doCallback(callback);
+        } else {
+            doneCallbacks.add(callback);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        boolean allCanceled = true;
+
+        for (Future<?> future : futures) {
+            if (!future.cancel(mayInterruptIfRunning)) {
+                allCanceled = false;
+            }
+        }
+
+        return allCanceled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        for (Future<?> future : futures) {
+            if (future.isCancelled()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        for (Future<?> future : futures) {
+            if (!future.isDone()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public List<T> get() throws InterruptedException, ExecutionException {
+        @Nullable ExecutionException exception = null;
+        @Nullable InterruptedException interruption = null;
+        List<T> result = new ArrayList<>(futures.size());
+
+        for (Future<? extends T> future : futures) {
+            try {
+                result.add(future.get());
+            } catch (InterruptedException e) {
+                if (interruption == null) {
+                    interruption = new InterruptedException();
+                }
+
+                interruption.addSuppressed(e);
+            } catch (ExecutionException e) {
+                if (exception == null) {
+                    exception = e;
+                } else {
+                    exception.addSuppressed(e);
+                }
+            } catch (RuntimeException e) {
+                // Yes, a little odd to catch RuntimeException, but we need to make sure we've
+                // examined all futures before returning.
+                if (exception == null) {
+                    exception = new ExecutionException(e);
+                } else {
+                    exception.addSuppressed(e);
+                }
+            }
+        }
+
+        if (exception != null) {
+            addSuppressed(exception, interruption);
+            throw exception;
+        }
+
+        if (interruption != null) {
+            throw interruption;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
+            TimeoutException {
+        @Nullable ExecutionException exception = null;
+        @Nullable InterruptedException interruption = null;
+        @Nullable TimeoutException timeoutException = null;
+        List<T> result = new ArrayList<>(futures.size());
+
+        for (Future<? extends T> future : futures) {
+            try {
+                // TODO: Technically we should take time left between calls
+                result.add(future.get(timeout, unit));
+            } catch (TimeoutException e) {
+                if (timeoutException == null) {
+                    timeoutException = e;
+                } else {
+                    timeoutException.addSuppressed(e);
+                }
+            } catch (InterruptedException e) {
+                if (interruption == null) {
+                    interruption = e;
+                } else {
+                    interruption.addSuppressed(e);
+                }
+            } catch (ExecutionException e) {
+                if (exception == null) {
+                    exception = e;
+                } else {
+                    exception.addSuppressed(e);
+                }
+            } catch (RuntimeException e) {
+                // Yes, a little odd to catch RuntimeException, but we need to make sure we've
+                // examined all futures before returning.
+                if (exception == null) {
+                    exception = new ExecutionException(e);
+                } else {
+                    exception.addSuppressed(e);
+                }
+            }
+        }
+
+        if (exception != null) {
+            addSuppressed(exception, interruption);
+            addSuppressed(exception, timeoutException);
+            throw exception;
+        }
+
+        if (interruption != null) {
+            addSuppressed(interruption, timeoutException);
+            throw interruption;
+        }
+
+        if (timeoutException != null) {
+            throw timeoutException;
+        }
+
+        return result;
+    }
+
+    private void doCallback(FutureDoneCallback futureDoneCallback) {
+        try {
+            futureDoneCallback.onDoneOrCancelled();
+        } catch (Exception e) {
+            // TODO log
+        }
+    }
+
+    private static void addSuppressed(@Nonnull Exception exception, @Nullable Exception toSuppress) {
+        if (toSuppress != null && exception != toSuppress) {
+            exception.addSuppressed(toSuppress);
+        }
+    }
+}

--- a/lib/src/main/java/org/esbtools/eventhandler/CombinedTransformingFuture.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/CombinedTransformingFuture.java
@@ -1,0 +1,81 @@
+package org.esbtools.eventhandler;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class CombinedTransformingFuture<T, U> implements TransformableFuture<U> {
+    private final CombinedTransformableFuture<T> combined;
+    private final FutureTransform<List<T>, U> futureTransform;
+
+    public CombinedTransformingFuture(CombinedTransformableFuture<T> combined,
+            FutureTransform<List<T>, U> futureTransform) {
+        this.combined = Objects.requireNonNull(combined, "combined");
+        this.futureTransform = Objects.requireNonNull(futureTransform, "futureTransform");
+    }
+
+    @Override
+    public <V> TransformableFuture<V> transformSync(FutureTransform<U, V> futureTransform) {
+        return new CombinedTransformingFuture<>(combined,
+                input -> futureTransform.transform(this.futureTransform.transform(input)));
+    }
+
+    @Override
+    public <V> TransformableFuture<V> transformAsync(FutureTransform<U,
+            TransformableFuture<V>> futureTransform) {
+        return new NestedTransformableFuture<>(
+                new CombinedTransformingFuture<>(combined,
+                        input -> futureTransform.transform(this.futureTransform.transform(input))));
+    }
+
+    @Override
+    public TransformableFuture<Void> transformAsyncIgnoringReturn(
+            FutureTransform<U, TransformableFuture<?>> futureTransform) {
+        return new NestedTransformableFutureIgnoringReturn(
+                new CombinedTransformingFuture<>(combined,
+                        input -> futureTransform.transform(this.futureTransform.transform(input))));
+    }
+
+    @Override
+    public TransformableFuture<U> whenDoneOrCancelled(FutureDoneCallback callback) {
+        combined.whenDoneOrCancelled(callback);
+        return this;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return combined.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return combined.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return combined.isDone();
+    }
+
+    @Override
+    public U get() throws InterruptedException, ExecutionException {
+        try {
+            return futureTransform.transform(combined.get());
+        } catch (Exception e) {
+            throw new ExecutionException(e);
+        }
+    }
+
+    @Override
+    public U get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
+            TimeoutException {
+        try {
+            return futureTransform.transform(combined.get(timeout, unit));
+        } catch (Exception e) {
+            throw new ExecutionException(e);
+        }
+    }
+
+}

--- a/lib/src/main/java/org/esbtools/eventhandler/TransformableFuture.java
+++ b/lib/src/main/java/org/esbtools/eventhandler/TransformableFuture.java
@@ -18,6 +18,7 @@
 
 package org.esbtools.eventhandler;
 
+import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -35,6 +36,14 @@ public interface TransformableFuture<T> extends Future<T> {
 
     static <T> TransformableFuture<T> immediateFailed(Exception exception) {
         return new FailedTransformableFuture<>(exception);
+    }
+
+    static <T> TransformableFuture<List<T>> combined(TransformableFuture<? extends T>... futures) {
+        return new CombinedTransformableFuture<>(futures);
+    }
+
+    static <T> TransformableFuture<List<T>> combined(List<TransformableFuture<? extends T>> futures) {
+        return new CombinedTransformableFuture<>(futures);
     }
 
     /**
@@ -86,7 +95,8 @@ public interface TransformableFuture<T> extends Future<T> {
      * returning a {@code Future<Future>} which would never have its result {@code Future} examined
      * because the consumer is ignoring the return value. This would definitely be a bug.
      */
-    TransformableFuture<Void> transformAsyncIgnoringReturn(FutureTransform<T, TransformableFuture<?>> futureTransform);
+    TransformableFuture<Void> transformAsyncIgnoringReturn(
+            FutureTransform<T, TransformableFuture<?>> futureTransform);
 
     /**
      * An asynchronous "finally" block.

--- a/lightblue/pom.xml
+++ b/lightblue/pom.xml
@@ -29,7 +29,7 @@
     <version>0.1.3-SNAPSHOT</version>
 
     <properties>
-        <version.event-handler-lib>0.1.2</version.event-handler-lib>
+        <version.event-handler-lib>0.1.3-SNAPSHOT</version.event-handler-lib>
         <version.lightblue-notification-hook-model>0.1.3</version.lightblue-notification-hook-model>
         <version.lightblue-java-generator>0.1.4</version.lightblue-java-generator>
         <version.lightblue-client>4.5.0</version.lightblue-client>


### PR DESCRIPTION
Please do not merge yet. Needs tests. Feel free to comment though.

This allows, among other things, for message implementations to share
logic with types that produce TransformableFutures, and combine
additional work on top of that. Put in other words, it allows any of
our Future based APIs to be implemented with any number of Futures
internally if they needed (rare but happens), as long as they are
returned combined.

The semantics of a combined future is [hopefully] what you would expect,
and follows Guava's Futures.allAsList. For example, cancel cancels all
futures, isCancelled returns true if any of the futures are cancelled,
isDone returns true only if all of the futures are done, etc.
