### PR TITLE
Parameterizing periodic routes to allow multiple instances

### DIFF
--- a/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRoute.java
+++ b/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRoute.java
@@ -41,7 +41,7 @@ public class PeriodicDeleteOldEntitiesRoute extends RouteBuilder {
     private final Duration deleteOlderThan;
     private final Duration deleteInterval;
     private final Clock clock;
-    private final String collectionDomain;
+    private final String domain;
     private final String entityName;
     private final String entityVersion;
     private final String entityDateField;
@@ -61,13 +61,13 @@ public class PeriodicDeleteOldEntitiesRoute extends RouteBuilder {
 
     public static PeriodicDeleteOldEntitiesRoute deletingDocumentEventsOlderThan(
             Duration deleteOlderThan, Duration deleteInterval, LightblueClient client,
-            String collectionDomain, LockStrategy lockStrategy, Clock clock) {
-        return new PeriodicDeleteOldEntitiesRoute( collectionDomain, DocumentEventEntity.ENTITY_NAME,
+            String domain, LockStrategy lockStrategy, Clock clock) {
+        return new PeriodicDeleteOldEntitiesRoute( domain, DocumentEventEntity.ENTITY_NAME,
                 DocumentEventEntity.VERSION, "creationDate", client, lockStrategy,
                 deleteOlderThan, deleteInterval, clock);
     }
 
-    public PeriodicDeleteOldEntitiesRoute(String collectionDomain, String entityName, String entityVersion,
+    public PeriodicDeleteOldEntitiesRoute(String domain, String entityName, String entityVersion,
             String entityDateField, LightblueClient client, LockStrategy lockStrategy,
             Duration deleteOlderThan, Duration deleteInterval, Clock clock) {
         this.client = client;
@@ -75,12 +75,12 @@ public class PeriodicDeleteOldEntitiesRoute extends RouteBuilder {
         this.deleteOlderThan = deleteOlderThan;
         this.deleteInterval = deleteInterval;
         this.clock = clock;
-        this.collectionDomain = collectionDomain;
+        this.domain = domain;
         this.entityName = entityName;
         this.entityVersion = entityVersion;
         this.entityDateField = entityDateField;
 
-        deleterLockResourceId = "old_" + collectionDomain + "_" + entityName + "_deleter";
+        deleterLockResourceId = "old_" + domain + "_" + entityName + "_deleter";
     }
 
     @Override

--- a/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRoute.java
+++ b/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRoute.java
@@ -53,8 +53,8 @@ public class PeriodicDeleteOldEntitiesRoute extends RouteBuilder {
 
     public static PeriodicDeleteOldEntitiesRoute deletingNotificationsOlderThan(
             Duration deleteOlderThan, Duration deleteInterval, LightblueClient client,
-            String collectionDomain, LockStrategy lockStrategy, Clock clock) {
-        return new PeriodicDeleteOldEntitiesRoute(collectionDomain, NotificationEntity.ENTITY_NAME,
+            String domain, LockStrategy lockStrategy, Clock clock) {
+        return new PeriodicDeleteOldEntitiesRoute(domain, NotificationEntity.ENTITY_NAME,
                 NotificationEntity.ENTITY_VERSION, "clientRequestDate", client, lockStrategy,
                 deleteOlderThan, deleteInterval, clock);
     }

--- a/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRoute.java
+++ b/lightblue/src/main/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRoute.java
@@ -41,6 +41,7 @@ public class PeriodicDeleteOldEntitiesRoute extends RouteBuilder {
     private final Duration deleteOlderThan;
     private final Duration deleteInterval;
     private final Clock clock;
+    private final String collectionDomain;
     private final String entityName;
     private final String entityVersion;
     private final String entityDateField;
@@ -52,21 +53,21 @@ public class PeriodicDeleteOldEntitiesRoute extends RouteBuilder {
 
     public static PeriodicDeleteOldEntitiesRoute deletingNotificationsOlderThan(
             Duration deleteOlderThan, Duration deleteInterval, LightblueClient client,
-            LockStrategy lockStrategy, Clock clock) {
-        return new PeriodicDeleteOldEntitiesRoute(NotificationEntity.ENTITY_NAME,
+            String collectionDomain, LockStrategy lockStrategy, Clock clock) {
+        return new PeriodicDeleteOldEntitiesRoute(collectionDomain, NotificationEntity.ENTITY_NAME,
                 NotificationEntity.ENTITY_VERSION, "clientRequestDate", client, lockStrategy,
                 deleteOlderThan, deleteInterval, clock);
     }
 
     public static PeriodicDeleteOldEntitiesRoute deletingDocumentEventsOlderThan(
             Duration deleteOlderThan, Duration deleteInterval, LightblueClient client,
-            LockStrategy lockStrategy, Clock clock) {
-        return new PeriodicDeleteOldEntitiesRoute(DocumentEventEntity.ENTITY_NAME,
+            String collectionDomain, LockStrategy lockStrategy, Clock clock) {
+        return new PeriodicDeleteOldEntitiesRoute( collectionDomain, DocumentEventEntity.ENTITY_NAME,
                 DocumentEventEntity.VERSION, "creationDate", client, lockStrategy,
                 deleteOlderThan, deleteInterval, clock);
     }
 
-    public PeriodicDeleteOldEntitiesRoute(String entityName, String entityVersion,
+    public PeriodicDeleteOldEntitiesRoute(String collectionDomain, String entityName, String entityVersion,
             String entityDateField, LightblueClient client, LockStrategy lockStrategy,
             Duration deleteOlderThan, Duration deleteInterval, Clock clock) {
         this.client = client;
@@ -74,11 +75,12 @@ public class PeriodicDeleteOldEntitiesRoute extends RouteBuilder {
         this.deleteOlderThan = deleteOlderThan;
         this.deleteInterval = deleteInterval;
         this.clock = clock;
+        this.collectionDomain = collectionDomain;
         this.entityName = entityName;
         this.entityVersion = entityVersion;
         this.entityDateField = entityDateField;
 
-        deleterLockResourceId = "old_" + entityName + "_deleter";
+        deleterLockResourceId = "old_" + collectionDomain + "_" + entityName + "_deleter";
     }
 
     @Override

--- a/lightblue/src/test/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRouteTest.java
+++ b/lightblue/src/test/java/org/esbtools/eventhandler/lightblue/PeriodicDeleteOldEntitiesRouteTest.java
@@ -85,10 +85,10 @@ public class PeriodicDeleteOldEntitiesRouteTest extends CamelTestSupport {
 
         docEventsDeleterRoute = PeriodicDeleteOldEntitiesRoute
                 .deletingDocumentEventsOlderThan(DELETE_OLDER_THAN, DELETE_INTERVAL,
-                        client, lockStrategy, fixedClock);
+                        client, "backoffice", lockStrategy, fixedClock);
         notificationsDeleterRoute = PeriodicDeleteOldEntitiesRoute
                 .deletingNotificationsOlderThan(DELETE_OLDER_THAN, DELETE_INTERVAL,
-                        client, lockStrategy, fixedClock);
+                        client, "backoffice", lockStrategy, fixedClock);
 
         // Reset locks, start with lock taken
         lockStrategy.releaseAll();


### PR DESCRIPTION
This is required to set up retention on more than one backing collection of notifications.